### PR TITLE
Sql transition

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ src/glimbot/schema.rs
 .env
 *.sqlite3*
 test/
+db.env

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -454,6 +454,9 @@ name = "either"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "encode_unicode"
@@ -1771,8 +1774,11 @@ dependencies = [
  "either",
  "futures",
  "heck",
+ "hex",
+ "once_cell",
  "proc-macro2",
  "quote",
+ "serde",
  "serde_json",
  "sha2",
  "sqlx-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee2a4ec343196209d6594e19543ae87a39f96d5534d7174822a3ad825dd6ed7e"
 
 [[package]]
+name = "ahash"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "739f4a8db6605981345c5654f3a85b056ce52f37a39d34da03f25bf2151ea16e"
+
+[[package]]
+name = "ahash"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "796540673305a66d127804eef19ad696f1f204b8c1025aaca4958c17eab32877"
+dependencies = [
+ "getrandom 0.2.2",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -87,6 +104,15 @@ dependencies = [
  "tokio-rustls",
  "tungstenite",
  "webpki-roots 0.20.0",
+]
+
+[[package]]
+name = "atoi"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "616896e05fc0e2649463a93a15183c6a16bf03413a7af88ef1285ddedfa9cda5"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -179,6 +205,12 @@ checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
 dependencies = [
  "generic-array",
 ]
+
+[[package]]
+name = "build_const"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39092a32794787acd8525ee150305ff051b0aa6cc2abaf193924f5ab05425f39"
 
 [[package]]
 name = "bumpalo"
@@ -285,12 +317,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "const_fn"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28b9d6de7f49e22cf97ad17fc4036ece69300032f45f78f30b4a4482cdc3f4a6"
-
-[[package]]
 name = "constant_time_eq"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -301,6 +327,15 @@ name = "cpuid-bool"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8aebca1129a03dc6dc2b127edd729435bbc4a37e1d5f4d7513165089ceb02634"
+
+[[package]]
+name = "crc"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d663548de7f5cca343f1e0a48d14dcfb0e9eb4e079ec58883b7251539fa10aeb"
+dependencies = [
+ "build_const",
+]
 
 [[package]]
 name = "crc32fast"
@@ -322,17 +357,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam-epoch"
-version = "0.9.1"
+name = "crossbeam-queue"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1aaa739f95311c2c7887a76863f500026092fb1dce0161dab577e559ef3569d"
+checksum = "0f6cb3c7f5b8e51bc3ebb73a2327ad4abdbd119dc13223f14f961d2f38486756"
 dependencies = [
  "cfg-if 1.0.0",
- "const_fn",
  "crossbeam-utils",
- "lazy_static",
- "memoffset",
- "scopeguard",
 ]
 
 [[package]]
@@ -344,6 +375,16 @@ dependencies = [
  "autocfg",
  "cfg-if 1.0.0",
  "lazy_static",
+]
+
+[[package]]
+name = "crypto-mac"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4857fd85a0c34b3c3297875b747c1e02e06b6a0ea32dd892d8192b9ce0813ea6"
+dependencies = [
+ "generic-array",
+ "subtle",
 ]
 
 [[package]]
@@ -458,16 +499,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fs2"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
-dependencies = [
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "fs_extra"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -575,15 +606,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fxhash"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
-dependencies = [
- "byteorder",
-]
-
-[[package]]
 name = "generic-array"
 version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -635,20 +657,20 @@ dependencies = [
  "downcast-rs",
  "futures",
  "humantime",
- "itertools",
+ "itertools 0.10.0",
  "jemallocator",
  "linked-hash-map",
  "once_cell",
  "regex",
- "rmp",
- "rmp-serde",
  "rust-embed",
  "serde",
+ "serde_json",
  "serenity",
  "shellexpand",
  "shlex",
- "sled",
+ "shrinkwraprs",
  "smallvec",
+ "sqlx",
  "strip-ansi-escapes",
  "structopt",
  "systemstat",
@@ -687,6 +709,18 @@ name = "hashbrown"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
+dependencies = [
+ "ahash 0.4.7",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d99cf782f0dc4372d26846bec3de7804ceb5df083c2d4462c0b8d2330e894fa8"
+dependencies = [
+ "hashbrown",
+]
 
 [[package]]
 name = "heck"
@@ -704,6 +738,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "322f4de77956e22ed0e5032c359a0f1273f1f7f0d79bfa3b8ffbc730d7fbcc5c"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "hex"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "644f9158b2f133fd50f5fb3242878846d9eb792e445c893805ff0e3824006e35"
+
+[[package]]
+name = "hmac"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1441c6b1e930e2817404b5046f1f989899143a12bf92de603b69f4e0aee1e15"
+dependencies = [
+ "crypto-mac",
+ "digest",
 ]
 
 [[package]]
@@ -831,6 +881,15 @@ checksum = "47be2f14c678be2fdcab04ab1171db51b2762ce6f0a8ee87c8dd4a04ed216135"
 
 [[package]]
 name = "itertools"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f56a2d0bc861f9165be4eb3442afd3c236d8a98afd426f65d92324ae1091a484"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37d572918e350e82412fe766d24b15e6682fb2ed2bbe018280caa810397cb319"
@@ -924,6 +983,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "maplit"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
+
+[[package]]
 name = "matchers"
 version = "0.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -939,19 +1004,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 
 [[package]]
+name = "md-5"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5a279bb9607f9f53c22d496eade00d138d1bdcccd07d74650387cf94942a15"
+dependencies = [
+ "block-buffer",
+ "digest",
+ "opaque-debug",
+]
+
+[[package]]
 name = "memchr"
 version = "2.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
-
-[[package]]
-name = "memoffset"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "157b4208e3059a8f9e78d559edc658e13df41410cb3ae03979c83130067fdd87"
-dependencies = [
- "autocfg",
-]
 
 [[package]]
 name = "mime"
@@ -1357,27 +1424,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rmp"
-version = "0.8.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f55e5fa1446c4d5dd1f5daeed2a4fe193071771a2636274d0d7a3b082aa7ad6"
-dependencies = [
- "byteorder",
- "num-traits",
-]
-
-[[package]]
-name = "rmp-serde"
-version = "0.15.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "839395ef53057db96b84c9238ab29e1a13f2e5c8ec9f66bef853ab4197303924"
-dependencies = [
- "byteorder",
- "rmp",
- "serde",
-]
-
-[[package]]
 name = "rust-argon2"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1498,6 +1544,7 @@ version = "1.0.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea1c6153794552ea7cf7cf63b1231a25de00ec90db326ba6264440fa08e31486"
 dependencies = [
+ "indexmap",
  "itoa",
  "ryu",
  "serde",
@@ -1554,6 +1601,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa827a14b29ab7f44778d14a88d3cb76e949c45083f7dbfa507d0cb699dc12de"
+dependencies = [
+ "block-buffer",
+ "cfg-if 1.0.0",
+ "cpuid-bool",
+ "digest",
+ "opaque-debug",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1578,6 +1638,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42a568c8f2cd051a4d283bd6eb0343ac214c1b0f1ac19f93e1175b2dee38c73d"
 
 [[package]]
+name = "shrinkwraprs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e63e6744142336dfb606fe2b068afa2e1cca1ee6a5d8377277a92945d81fa331"
+dependencies = [
+ "bitflags",
+ "itertools 0.8.2",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1591,22 +1664,6 @@ name = "slab"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
-
-[[package]]
-name = "sled"
-version = "0.34.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d0132f3e393bcb7390c60bb45769498cf4550bcb7a21d7f95c02b69f6362cdc"
-dependencies = [
- "crc32fast",
- "crossbeam-epoch",
- "crossbeam-utils",
- "fs2",
- "fxhash",
- "libc",
- "log",
- "parking_lot",
-]
 
 [[package]]
 name = "smallvec"
@@ -1632,10 +1689,124 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
+name = "sqlformat"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d86e3c77ff882a828346ba401a7ef4b8e440df804491c6064fe8295765de71c"
+dependencies = [
+ "lazy_static",
+ "maplit",
+ "nom",
+ "regex",
+ "unicode_categories",
+]
+
+[[package]]
+name = "sqlx"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2739d54a2ae9fdd0f545cb4e4b5574efb95e2ec71b7f921678e246fb20dcaaf"
+dependencies = [
+ "sqlx-core",
+ "sqlx-macros",
+]
+
+[[package]]
+name = "sqlx-core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1cad9cae4ca8947eba1a90e8ec7d3c59e7a768e2f120dc9013b669c34a90711"
+dependencies = [
+ "ahash 0.6.3",
+ "atoi",
+ "base64 0.13.0",
+ "bitflags",
+ "byteorder",
+ "bytes 1.0.1",
+ "chrono",
+ "crc",
+ "crossbeam-channel",
+ "crossbeam-queue",
+ "crossbeam-utils",
+ "either",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "hashlink",
+ "hex",
+ "hmac",
+ "itoa",
+ "libc",
+ "log",
+ "md-5",
+ "memchr",
+ "once_cell",
+ "parking_lot",
+ "percent-encoding",
+ "rand",
+ "rustls",
+ "serde",
+ "serde_json",
+ "sha-1",
+ "sha2",
+ "smallvec",
+ "sqlformat",
+ "sqlx-rt",
+ "stringprep",
+ "thiserror",
+ "tokio-stream",
+ "url",
+ "webpki",
+ "webpki-roots 0.21.0",
+ "whoami",
+]
+
+[[package]]
+name = "sqlx-macros"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01caee2b3935b4efe152f3262afbe51546ce3b1fc27ad61014e1b3cf5f55366e"
+dependencies = [
+ "dotenv",
+ "either",
+ "futures",
+ "heck",
+ "proc-macro2",
+ "quote",
+ "serde_json",
+ "sha2",
+ "sqlx-core",
+ "sqlx-rt",
+ "syn",
+ "url",
+]
+
+[[package]]
+name = "sqlx-rt"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ce2e16b6774c671cc183e1d202386fdf9cde1e8468c1894a7f2a63eb671c4f4"
+dependencies = [
+ "once_cell",
+ "tokio",
+ "tokio-rustls",
+]
+
+[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "stringprep"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee348cb74b87454fff4b551cbf727025810a004f88aeacae7f85b87f4e9a1c1"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+]
 
 [[package]]
 name = "strip-ansi-escapes"
@@ -1675,6 +1846,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "subtle"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e81da0851ada1f3e9d4312c704aa4f8806f0f9d69faaf8df2f3464b4a9437c2"
 
 [[package]]
 name = "syn"
@@ -2033,6 +2210,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
 
 [[package]]
+name = "unicode_categories"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
+
+[[package]]
 name = "untrusted"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2220,6 +2403,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82015b7e0b8bad8185994674a13a93306bea76cf5a16c5a181382fd3a5ec2376"
 dependencies = [
  "webpki",
+]
+
+[[package]]
+name = "whoami"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a921c0ad578a51c0b6c0bbb9b95f0ed11e90d61da506139e48a946edd11ee1e"
+dependencies = [
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,8 +20,6 @@ exclude = [".env"]
 
 [dependencies]
 dotenv = "0.15"
-
-sled = "0.34"
 regex = "1.4"
 clap = "2"
 anyhow = "1"
@@ -43,8 +41,7 @@ dirs = "3.0"
 byteorder = "1"
 humantime = "2.1"
 serde = { version = "1.0", features = ["derive"] }
-rmp = "0.8.10"
-rmp-serde = "0.15"
+serde_json = "1.0"
 tokio = { version = "1.2", features = ["full"] }
 tokio-stream = "0.1"
 systemstat = "0.1"
@@ -52,7 +49,9 @@ downcast-rs = "1.2"
 rust-embed = "5.9.0"
 itertools = "0.10"
 strip-ansi-escapes = "0.1.0"
+shrinkwraprs = "0.3"
 smallvec = "1.6"
+sqlx = {version = "0.5", features = ["runtime-tokio-rustls", "postgres", "migrate", "chrono", "json"]}
 
 [dependencies.serenity]
 version = "0.10"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ itertools = "0.10"
 strip-ansi-escapes = "0.1.0"
 shrinkwraprs = "0.3"
 smallvec = "1.6"
-sqlx = {version = "0.5", features = ["runtime-tokio-rustls", "postgres", "migrate", "chrono", "json"]}
+sqlx = {version = "0.5", features = ["runtime-tokio-rustls", "postgres", "migrate", "chrono", "json", "offline"]}
 
 [dependencies.serenity]
 version = "0.10"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,17 @@
+version: "3.8"
+
+services:
+  db:
+    image: postgres
+    volumes:
+      - db-data:/var/lib/postgresql/data
+    ports:
+      - 5432:5432
+    environment:
+      - POSTGRES_PASSWORD=${GLIMBOT_DB_PASS}
+      - POSTGRES_USER=${GLIMBOT_DB_USER}
+    restart: always
+
+volumes:
+  db-data:
+    driver: local

--- a/examples/example.env
+++ b/examples/example.env
@@ -1,3 +1,4 @@
 GLIMBOT_TOKEN=<discord token>
 GLIMBOT_OWNER=<user id>
 GLIMBOT_LOG=info
+DATABASE_URL=<postgresql URL>

--- a/migrations/20210301041112_init.sql
+++ b/migrations/20210301041112_init.sql
@@ -1,0 +1,96 @@
+CREATE TABLE known_guilds
+(
+    guild             BIGINT PRIMARY KEY,
+    joinable_role_cnt INT NOT NULL DEFAULT 0
+        CONSTRAINT reasonable_role_count CHECK (joinable_role_cnt >= 0 AND joinable_role_cnt <= 128)
+);
+
+CREATE TABLE config_values
+(
+    guild BIGINT,
+    name  TEXT,
+    value JSONB NOT NULL,
+    PRIMARY KEY (guild, name),
+    FOREIGN KEY (guild)
+        REFERENCES known_guilds (guild)
+        ON DELETE CASCADE
+);
+
+CREATE TABLE joinable_roles
+(
+    guild BIGINT,
+    role  BIGINT,
+    PRIMARY KEY (guild, role),
+    FOREIGN KEY (guild)
+        REFERENCES known_guilds (guild)
+        ON DELETE CASCADE
+);
+
+CREATE OR REPLACE FUNCTION ensure_guild()
+    RETURNS TRIGGER
+    LANGUAGE plpgsql
+AS
+$$
+BEGIN
+    INSERT INTO known_guilds (guild) VALUES (NEW.guild) ON CONFLICT DO NOTHING;
+    RETURN NEW;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION get_or_insert_config(gid BIGINT, cfg_name TEXT, INOUT res JSONB)
+    LANGUAGE plpgsql
+    VOLATILE
+AS
+$$
+BEGIN
+    INSERT INTO config_values (guild, name, value) VALUES (gid, cfg_name, res)
+    ON CONFLICT DO NOTHING;
+    SELECT value FROM config_values WHERE guild = gid AND name = cfg_name INTO res;
+END;
+$$;
+
+CREATE TRIGGER ensure_config_guild
+    BEFORE INSERT OR UPDATE
+    ON config_values
+    FOR EACH ROW
+EXECUTE PROCEDURE ensure_guild();
+
+CREATE TRIGGER ensure_joinable_guild
+    BEFORE INSERT OR UPDATE
+    ON joinable_roles
+    FOR EACH ROW
+EXECUTE PROCEDURE ensure_guild();
+
+CREATE OR REPLACE FUNCTION joinable_roles_limit()
+    RETURNS TRIGGER
+    LANGUAGE plpgsql
+AS
+$$
+BEGIN
+    UPDATE known_guilds SET joinable_role_cnt = joinable_role_cnt + 1 WHERE guild = NEW.guild;
+    RETURN NEW;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION update_roles_cnt()
+    RETURNS TRIGGER
+    LANGUAGE plpgsql
+AS
+$$
+BEGIN
+    UPDATE known_guilds SET joinable_role_cnt = joinable_role_cnt - 1 WHERE guild = NEW.guild;
+    RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER enforce_joinable_roles_limit
+    AFTER INSERT
+    ON joinable_roles
+    FOR EACH ROW
+EXECUTE PROCEDURE joinable_roles_limit();
+
+CREATE TRIGGER update_joinable_roles_cnt
+    BEFORE DELETE
+    ON joinable_roles
+    FOR EACH ROW
+EXECUTE PROCEDURE update_roles_cnt();

--- a/sqlx-data.json
+++ b/sqlx-data.json
@@ -1,0 +1,127 @@
+{
+  "db": "PostgreSQL",
+  "054b1bfb822cee862be30946b7aa04e67b39240d3beffd63ccf6552b60bc791e": {
+    "query": "\n            INSERT INTO config_values (guild, name, value)\n            VALUES ($1, $2, $3)\n            ON CONFLICT (guild, name) DO UPDATE\n                SET value = EXCLUDED.value;\n            ",
+    "describe": {
+      "columns": [],
+      "parameters": {
+        "Left": [
+          "Int8",
+          "Text",
+          "Jsonb"
+        ]
+      },
+      "nullable": []
+    }
+  },
+  "2d16b542737d2576d08c84d60ff93d3ea44f9162aa3cd94dd1638f4cee4ef92d": {
+    "query": "INSERT INTO joinable_roles (guild, role) VALUES ($1, $2);",
+    "describe": {
+      "columns": [],
+      "parameters": {
+        "Left": [
+          "Int8",
+          "Int8"
+        ]
+      },
+      "nullable": []
+    }
+  },
+  "3b4079af7469d269a6f46bfe90524e32ffab3ee31da76997c0f2e6dbf71ede2f": {
+    "query": "DELETE FROM joinable_roles WHERE guild = $1 AND role = $2;",
+    "describe": {
+      "columns": [],
+      "parameters": {
+        "Left": [
+          "Int8",
+          "Int8"
+        ]
+      },
+      "nullable": []
+    }
+  },
+  "4f7e8fb83bd3feb0cad3584912af6e93810f7c4c821c37e31adf807defe08b2f": {
+    "query": "SELECT role FROM joinable_roles WHERE guild = $1 ORDER BY role ASC;",
+    "describe": {
+      "columns": [
+        {
+          "ordinal": 0,
+          "name": "role",
+          "type_info": "Int8"
+        }
+      ],
+      "parameters": {
+        "Left": [
+          "Int8"
+        ]
+      },
+      "nullable": [
+        false
+      ]
+    }
+  },
+  "944df845c3416c503d6c08ea8aed3bf03791c0d0ebd910e740901b2fb61fc822": {
+    "query": "SELECT COUNT(*) AS matching FROM joinable_roles WHERE guild = $1 AND role = $2;",
+    "describe": {
+      "columns": [
+        {
+          "ordinal": 0,
+          "name": "matching",
+          "type_info": "Int8"
+        }
+      ],
+      "parameters": {
+        "Left": [
+          "Int8",
+          "Int8"
+        ]
+      },
+      "nullable": [
+        null
+      ]
+    }
+  },
+  "b623ff8c0ba7b8ad23fb65599ebc0b888c7d9bae0ec6a8d5e81cfb30ac3d6c75": {
+    "query": "\n            SELECT value FROM config_values WHERE guild = $1 AND name = $2;\n            ",
+    "describe": {
+      "columns": [
+        {
+          "ordinal": 0,
+          "name": "value",
+          "type_info": "Jsonb"
+        }
+      ],
+      "parameters": {
+        "Left": [
+          "Int8",
+          "Text"
+        ]
+      },
+      "nullable": [
+        false
+      ]
+    }
+  },
+  "efa07a1adcb7f2711bef6d34826e453d4fe36bfc61526a012c06a55d350c063a": {
+    "query": "\n                SELECT res AS value FROM get_or_insert_config($1, $2, $3);\n                ",
+    "describe": {
+      "columns": [
+        {
+          "ordinal": 0,
+          "name": "value",
+          "type_info": "Jsonb"
+        }
+      ],
+      "parameters": {
+        "Left": [
+          "Int8",
+          "Text",
+          "Jsonb"
+        ]
+      },
+      "nullable": [
+        null
+      ]
+    }
+  }
+}

--- a/src/example.rs
+++ b/src/example.rs
@@ -16,7 +16,7 @@ pub fn subcommand() -> clap::App<'static, 'static> {
         .about("Create a config file with placeholders to fill for a working dotenv file.")
 }
 
-pub async fn handle_matches(args: &ArgMatches<'_>) -> anyhow::Result<()> {
+pub async fn handle_matches(args: &ArgMatches<'_>) -> crate::error::Result<()> {
     let of = args.value_of("output-file").unwrap();
     let example_contents: Cow<[u8]> = ExampleEnv::get("example.env").unwrap();
     tokio::fs::write(of, &example_contents).await?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,6 +15,7 @@
 
 #[macro_use] extern crate tracing;
 #[macro_use] extern crate serde;
+#[macro_use] extern crate sqlx;
 
 #[macro_use]
 mod error;
@@ -40,7 +41,7 @@ static GLOBAL: Jemalloc = Jemalloc;
 
 #[doc(hidden)] // it's a main function
 #[tokio::main]
-async fn main() -> anyhow::Result<()> {
+async fn main() -> crate::error::Result<()> {
     better_panic::install();
     let _ = dotenv::dotenv()?;
     let sub = FmtSubscriber::builder()

--- a/src/module/privilege.rs
+++ b/src/module/privilege.rs
@@ -50,7 +50,7 @@ impl Module for PrivilegeFilter {
 
         // Gotta hit the DB
         let v = dis.config_value_t::<VerifiedRole>(PRIV_NAME)?;
-        let db = DbContext::new(orig.guild_id.unwrap()).await?;
+        let db = DbContext::new(dis.pool(), orig.guild_id.unwrap());
         let mod_role = v.get(&db).await?
             .ok_or_else(|| UserError::new("Need to set a moderator role -- see privileged_role config option."))?;
 

--- a/src/run.rs
+++ b/src/run.rs
@@ -2,12 +2,11 @@ use serenity::client::bridge::gateway::GatewayIntents;
 use crate::module::status::START_TIME;
 use once_cell::sync::Lazy;
 use crate::dispatch::ShardManKey;
-use crate::db::ensure_db;
-
 // Starts Glimbot.
-pub async fn start_bot() -> anyhow::Result<()> {
+pub async fn start_bot() -> crate::error::Result<()> {
 
-    let mut dispatch = crate::dispatch::Dispatch::new(std::env::var("GLIMBOT_OWNER").expect("Couldn't find owner information.").parse().expect("Invalid owner token."));
+    let pool = crate::db::create_pool().await?;
+    let mut dispatch = crate::dispatch::Dispatch::new(std::env::var("GLIMBOT_OWNER").expect("Couldn't find owner information.").parse().expect("Invalid owner token."), pool);
     dispatch.add_module(crate::module::base_filter::BaseFilter);
     dispatch.add_module(crate::module::owner::OwnerFilter);
     dispatch.add_module(crate::module::privilege::PrivilegeFilter);


### PR DESCRIPTION
Moving to PostgreSQL from Sled

- Sled ended up being a little too low level; a lot of dev time for implementing timed events was being spent reimplementing `SELECT * FROM timed WHERE time < now();`
- Apparently not everything can be solved by KV stores.
- PostgreSQL is stable; Sled is still in beta.

May return to Sled in the future as an in-memory cache, especially for config values.